### PR TITLE
Update README.md to reference providers.tf not versions.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repo is meant to help people to learn the basics of the Harvester Terraform
 ```
 git clone https://github.com/avaleror/harvester-terraform.git
 cd /whateverpath/harvester-terraform
-vim versions.tf #update the path for your Harvester Kubeconfig
+vim providers.tf #update the path for your Harvester Kubeconfig
 vim networks.tf #Add the network parameters for your cluster, otherwise the network and the VM will be created, but the VM won't have an IP
 terraform init
 terraform plan -out "tfplan"


### PR DESCRIPTION
A simple change. The README.md says that people should edit the kubectl path in versions.tf, but there is no such file in the repo. providers.tf does in fact have the kubectl defined within it, so that is the correct file name.